### PR TITLE
Simplify way of file management

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,12 @@ import (
 
 const envPrefix = "PROTOBUF_LSP"
 
+var (
+	DefaultLSPConfig = LSP{
+		TextDocumentSyncKind: protocol.Full,
+	}
+)
+
 // Config represents a configuration for server.
 type Config struct {
 	Env    Env

--- a/pkg/lsp/server/definition.go
+++ b/pkg/lsp/server/definition.go
@@ -33,13 +33,9 @@ func (s *Server) definition(ctx context.Context, params *protocol.TextDocumentPo
 	uri := params.TextDocument.URI
 	filename := uri.Filename()
 
-	view, ok := s.session.ViewOf(uri)
-	if !ok {
-		logger.Warn("view not found", zap.String("filename", filename))
-		return
-	}
+	v := s.session.ViewOf(uri)
 
-	f, err := view.GetFile(uri)
+	f, err := v.GetFile(uri)
 	if err != nil {
 		logger.Error("file not found", zap.String("filename", filename))
 		return

--- a/pkg/lsp/server/general.go
+++ b/pkg/lsp/server/general.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-language-server/protocol"
 	"github.com/go-language-server/uri"
 
-	"github.com/micnncim/protocol-buffers-language-server/pkg/lsp/source"
+	"github.com/micnncim/protocol-buffers-language-server/pkg/config"
 )
 
 func (s *Server) initialize(ctx context.Context, params *protocol.InitializeParams) (result *protocol.InitializeResult, err error) {
@@ -59,14 +59,18 @@ func (s *Server) initialize(ctx context.Context, params *protocol.InitializePara
 	}
 
 	for _, folder := range folders {
-		view := source.NewView(s.session, folder.Name, uri.File(folder.URI))
-		s.session.AddView(ctx, view)
+		s.addView(ctx, folder.Name, uri.File(folder.URI))
 	}
+
+	cfg := config.DefaultLSPConfig
 
 	result = &protocol.InitializeResult{
 		Capabilities: protocol.ServerCapabilities{
-			TextDocumentSync: nil,
-			HoverProvider:    false,
+			TextDocumentSync: protocol.TextDocumentSyncOptions{
+				OpenClose: true,
+				Change:    float64(cfg.TextDocumentSyncKind),
+			},
+			HoverProvider: false,
 			CompletionProvider: &protocol.CompletionOptions{
 				TriggerCharacters: []string{"."},
 			},

--- a/pkg/lsp/source/BUILD.bazel
+++ b/pkg/lsp/source/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/micnncim/protocol-buffers-language-server/pkg/lsp/source",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/proto/parser:go_default_library",
         "//pkg/proto/registry:go_default_library",
         "@com_github_go_language_server_uri//:go_default_library",
         "@org_uber_go_atomic//:go_default_library",

--- a/pkg/lsp/source/file.go
+++ b/pkg/lsp/source/file.go
@@ -66,7 +66,7 @@ type file struct {
 var _ File = (*file)(nil)
 
 type protoFile struct {
-	file
+	File
 	proto registry.Proto
 }
 

--- a/pkg/lsp/source/file.go
+++ b/pkg/lsp/source/file.go
@@ -20,7 +20,6 @@ package source
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-language-server/uri"
 
@@ -31,69 +30,76 @@ import (
 type File interface {
 	URI() uri.URI
 	View() View
-	Handle(ctx context.Context) FileHandle
+	FileSystem() FileSystem
+	Read(ctx context.Context) ([]byte, string, error)
+
+	Saved() bool
+	// TODO: Fix appropriate function name.
+	SetSaved(saved bool)
 }
 
 type ProtoFile interface {
 	File
 	Proto() registry.Proto
-}
-
-// FileHandle represents a handle to a specific version of a single file from
-// a specific file system.
-type FileHandle interface {
-	// FileSystem returns the file system this handle was acquired from.
-	FileSystem() FileSystem
-
-	// Read reads the contents of a file and returns it along with its hash value.
-	// If the file is not available, returns a nil slice and an error.
-	Read(ctx context.Context) ([]byte, string, error)
+	SetProto(proto registry.Proto)
 }
 
 // FileSystem is the interface to something that provides file contents.
 type FileSystem interface {
-	// GetFile returns a handle for the specified file.
-	GetFile(uri uri.URI) FileHandle
+	// GetFile returns a file whose the given uri.
+	GetFile(uri uri.URI) (File, error)
 }
 
-// fileBase implements File.
-// fileBase holds the common functionality for all files.
-// It is intended to be embedded in the file implementations.
-type fileBase struct {
-	uri uri.URI
+// file is a file for changed files.
+type file struct {
+	session Session
+	view    View
 
-	view View
+	uri  uri.URI
+	data []byte
+	hash string
 
-	handleMu *sync.RWMutex
-	handle   FileHandle
+	// saved is true if a file has been saved on disk.
+	saved bool
 }
 
-var _ File = (*fileBase)(nil)
-
-func (f *fileBase) URI() uri.URI {
-	return f.uri
-}
-
-func (f *fileBase) View() View {
-	return f.view
-}
-
-func (f *fileBase) Handle(ctx context.Context) FileHandle {
-	f.handleMu.Lock()
-	defer f.handleMu.Unlock()
-	if f.handle == nil {
-		f.handle = f.view.Session().GetFile(f.URI())
-	}
-	return f.handle
-}
+var _ File = (*file)(nil)
 
 type protoFile struct {
-	fileBase
+	file
 	proto registry.Proto
 }
 
 var _ ProtoFile = (*protoFile)(nil)
 
-func (f *protoFile) Proto() registry.Proto {
-	return f.proto
+func (f *file) URI() uri.URI {
+	return f.uri
+}
+
+func (f *file) View() View {
+	return f.view
+}
+
+func (f *file) FileSystem() FileSystem {
+	return f.view
+}
+
+func (f *file) Read(context.Context) ([]byte, string, error) {
+	return f.data, f.hash, nil
+}
+
+func (f *file) Saved() bool {
+	return f.saved
+}
+
+func (f *file) SetSaved(saved bool) {
+	f.saved = saved
+}
+
+func (p *protoFile) Proto() registry.Proto {
+	return p.proto
+}
+
+func (p *protoFile) SetProto(proto registry.Proto) {
+	p.proto = proto
 }

--- a/pkg/lsp/source/session.go
+++ b/pkg/lsp/source/session.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/go-language-server/uri"
@@ -34,12 +35,8 @@ var (
 )
 
 // Session represents a single connection from a client.
-// This is the level at which things like open files are maintained on behalf
-// of the client.
-// A session may have many active views at any given time.
+// A session just manages views and does not access files directly.
 type Session interface {
-	FileSystem
-
 	// AddView creates a new View, adds it to the Session and returns it.
 	AddView(ctx context.Context, view View)
 
@@ -50,27 +47,13 @@ type Session interface {
 	View(name string) (View, bool)
 
 	// ViewOf returns a view corresponding to the given URI.
-	ViewOf(uri uri.URI) (View, bool)
+	ViewOf(uri uri.URI) View
 
 	// Views returns the set of active views built by this session.
 	Views() []View
 
 	// Shutdown the session and all views it has created.
 	Shutdown(ctx context.Context)
-
-	// DidOpen is invoked each time a file is opened in the editor.
-	DidOpen(ctx context.Context, uri uri.URI, text []byte)
-
-	// DidSave is invoked each time an open file is saved in the editor.
-	DidSave(uri uri.URI)
-
-	// DidClose is invoked each time an open file is closed in the editor.
-	DidClose(uri uri.URI)
-
-	// IsOpen can be called to check if the editor has a file currently open.
-	IsOpen(uri uri.URI) bool
-
-	SetOverlay(uri uri.URI, data []byte) (isFirstChange bool)
 }
 
 type session struct {
@@ -79,52 +62,17 @@ type session struct {
 	views   []View
 	viewMap map[uri.URI]View
 	viewMu  *sync.RWMutex
-
-	overlayMu *sync.RWMutex
-	overlays  map[uri.URI]*Overlay
-
-	openFiles   map[uri.URI]bool
-	openFilesMu *sync.RWMutex
 }
 
 var _ Session = (*session)(nil)
-var _ FileSystem = (*session)(nil)
-
-// Overlay is an Overlay for changed files.
-type Overlay struct {
-	session Session
-	uri     uri.URI
-	data    []byte
-	hash    string
-
-	// saved is true if a file has been saved on disk.
-	saved bool
-
-	// unchanged is true if a file has not yet been edited.
-	unchanged bool
-}
-
-var _ FileHandle = (*Overlay)(nil)
 
 // NewSession returns Session.
 func NewSession() Session {
 	return &session{
-		id:          sessionIndex.Add(1),
-		viewMap:     make(map[uri.URI]View),
-		viewMu:      &sync.RWMutex{},
-		openFiles:   make(map[uri.URI]bool),
-		openFilesMu: &sync.RWMutex{},
+		id:      sessionIndex.Add(1),
+		viewMap: make(map[uri.URI]View),
+		viewMu:  &sync.RWMutex{},
 	}
-}
-
-func (s *session) GetFile(uri uri.URI) FileHandle {
-	s.overlayMu.RLock()
-	overlay, ok := s.getOverlay(uri)
-	s.overlayMu.RUnlock()
-	if ok {
-		return overlay
-	}
-	return nil
 }
 
 func (s *session) AddView(ctx context.Context, view View) {
@@ -166,11 +114,19 @@ func (s *session) View(name string) (View, bool) {
 	return nil, false
 }
 
-func (s *session) ViewOf(uri uri.URI) (v View, ok bool) {
+func (s *session) ViewOf(uri uri.URI) View {
 	s.viewMu.RLock()
-	v, ok = s.viewMap[uri]
+	// uri is folder and matches one of viewMap.
+	v, ok := s.viewMap[uri]
+	if ok {
+		return v
+	}
 	s.viewMu.RUnlock()
-	return v, ok
+
+	v = s.bestView(uri)
+	s.viewMap[uri] = v
+
+	return v
 }
 
 func (s *session) Views() []View {
@@ -185,7 +141,7 @@ func (s *session) Views() []View {
 	return views
 }
 
-func (s *session) Shutdown(ctx context.Context) {
+func (s *session) Shutdown(context.Context) {
 	s.viewMu.Lock()
 	defer s.viewMu.Unlock()
 
@@ -193,86 +149,24 @@ func (s *session) Shutdown(ctx context.Context) {
 	s.viewMap = nil
 }
 
-func (s *session) DidOpen(ctx context.Context, uri uri.URI, text []byte) {
-	s.openFilesMu.Lock()
-	s.openFiles[uri] = true
-	s.openFilesMu.Unlock()
-	s.openOverlay(ctx, uri, text)
-}
-
-func (s *session) DidSave(uri uri.URI) {
-	s.overlayMu.Lock()
-	if overlay, ok := s.overlays[uri]; ok {
-		overlay.saved = true
+// bestView finds the best view to associate a given URI with.
+// viewMu must be held when calling this method.
+func (s *session) bestView(uri uri.URI) View {
+	// we need to find the best view for this file
+	var longest View
+	for _, view := range s.views {
+		if longest != nil && len(longest.Folder()) > len(view.Folder()) {
+			continue
+		}
+		if strings.HasPrefix(string(uri), string(view.Folder())) {
+			longest = view
+		}
 	}
-	s.overlayMu.Unlock()
-}
-
-func (s *session) DidClose(uri uri.URI) {
-	s.openFilesMu.Lock()
-	delete(s.openFiles, uri)
-	s.openFilesMu.Unlock()
-}
-
-func (s *session) IsOpen(uri uri.URI) bool {
-	s.openFilesMu.RLock()
-	defer s.openFilesMu.RUnlock()
-
-	open, ok := s.openFiles[uri]
-	if !ok {
-		return false
+	if longest != nil {
+		return longest
 	}
-	return open
-}
-
-func (s *session) SetOverlay(uri uri.URI, data []byte) (isFirstChange bool) {
-	s.overlayMu.Lock()
-	defer s.overlayMu.Unlock()
-
-	if data == nil {
-		delete(s.overlays, uri)
-		return
-	}
-
-	o := s.overlays[uri]
-
-	s.overlays[uri] = &Overlay{
-		session:   s,
-		uri:       uri,
-		data:      data,
-		hash:      hashContent(data),
-		unchanged: o == nil,
-	}
-
-	isFirstChange = o != nil && o.unchanged
-	return
-}
-
-func (s *session) getOverlay(uri uri.URI) (overlay *Overlay, ok bool) {
-	s.overlayMu.RLock()
-	overlay, ok = s.overlays[uri]
-	s.overlayMu.RUnlock()
-	return
-}
-
-func (s *session) openOverlay(_ context.Context, uri uri.URI, data []byte) {
-	s.overlayMu.Lock()
-	s.overlays[uri] = &Overlay{
-		session:   s,
-		uri:       uri,
-		data:      data,
-		hash:      hashContent(data),
-		unchanged: true,
-	}
-	s.overlayMu.Unlock()
-}
-
-func (o *Overlay) FileSystem() FileSystem {
-	return o.session
-}
-
-func (o *Overlay) Read(context.Context) ([]byte, string, error) {
-	return o.data, o.hash, nil
+	// TODO: are there any more heuristics we can use?
+	return s.views[0]
 }
 
 func hashContent(content []byte) string {

--- a/pkg/lsp/source/session.go
+++ b/pkg/lsp/source/session.go
@@ -89,13 +89,14 @@ func (s *session) View(name string) (View, bool) {
 }
 
 func (s *session) ViewOf(uri uri.URI) View {
-	s.viewMu.RLock()
+	s.viewMu.Lock()
+	defer s.viewMu.Unlock()
+
 	// uri is folder and matches one of viewMap.
 	v, ok := s.viewMap[uri]
 	if ok {
 		return v
 	}
-	s.viewMu.RUnlock()
 
 	v = s.bestView(uri)
 	s.viewMap[uri] = v

--- a/pkg/lsp/source/sourcetest/BUILD.bazel
+++ b/pkg/lsp/source/sourcetest/BUILD.bazel
@@ -36,7 +36,6 @@ gomock(
     out = "source.mock.go",
     interfaces = [
         "File",
-        "FileHandle",
         "FileSystem",
         "Session",
         "View",

--- a/pkg/lsp/source/view.go
+++ b/pkg/lsp/source/view.go
@@ -99,8 +99,8 @@ func NewView(session Session, name string, folder uri.URI) View {
 		filesByBase:  make(map[string][]File),
 		openFiles:    make(map[uri.URI]bool),
 		openFileMu:   &sync.RWMutex{},
-		ignoredURIMu: nil,
-		ignoredURIs:  nil,
+		ignoredURIs:  make(map[uri.URI]struct{}),
+		ignoredURIMu: &sync.RWMutex{},
 	}
 }
 

--- a/pkg/lsp/source/view.go
+++ b/pkg/lsp/source/view.go
@@ -205,13 +205,6 @@ func (v *view) IsOpen(uri uri.URI) bool {
 	return open
 }
 
-func (v *view) getFile(uri uri.URI) (file File, ok bool) {
-	v.fileMu.RLock()
-	file, ok = v.filesByURI[uri]
-	v.fileMu.RUnlock()
-	return
-}
-
 func (v *view) openFile(uri uri.URI, data []byte) {
 	v.fileMu.Lock()
 	v.filesByURI[uri] = &file{


### PR DESCRIPTION
## What this PR does / Why we need it

- Got to accept full change
- Changed roles of `Session`, `View` and `File`
  - `Session`: controls `View`s
  - `View`: manages `File`s
  - `File`: has data (`[]byte`) and proto (`registry.Proto`) lastly successfully parsed

## Which issue(s) this PR fixes

Fixes #
